### PR TITLE
Updates for 4.0.13/4.1.0 releases

### DIFF
--- a/content/installation/_index.md
+++ b/content/installation/_index.md
@@ -274,5 +274,5 @@ kubectl directpv install
 To install using generated manifests file, use the following command.
 
 ```sh {.copy}
-curl -sfL https://github.com/minio/directpv/raw/master/docs/tools/install.sh | sh - apply
+curl -sfL https://github.com/minio/directpv/raw/master/docs/tools/install.sh | sh -s - apply
 ```

--- a/content/installation/upgrade.md
+++ b/content/installation/upgrade.md
@@ -11,6 +11,16 @@ Custom installations do not support client-side upgrade functionality.
 Use [`kubectl directpv migrate`]({{< relref "/command-line/migrate.md" >}}) to migrate the old resources to a new installation.
 {{< /admonition >}}
 
+{{< admonition title="Pod Security Policies" type="note" >}}
+The `PodSecurityPolicy` feature was deprecated in Kubernetes v1.21 and removed in v1.25.
+The oldest supported release of Kubernetes is v1.28.
+The [Kubernetes Documentation](https://kubernetes.io/docs/concepts/security/pod-security-policy/) recommends [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a replacement.
+
+DirectPV continues to support `PodSecurityPolicy` in the 4.0.x lineage.
+The latest version of DirectPV, 4.1.x and later, removed support for `PodSecurityPolicy`.
+
+If you rely on `PodSecurityPolicy`, you **must** remain on the 4.0.x lineage of DirectPV and **must not** upgrade to a 4.1.x release or later.
+{{< /admonition >}}
 
 ## Upgrade DirectPV CSI Driver from 4.x.x to latest
 
@@ -51,9 +61,30 @@ Follow the steps below to perform an in-place upgrade:
 2. Run the install script with the appropriate node-selector, tolerations, and `KUBELET_DIR_PATH` environment variables needed for your environment.
 
    ```sh {.copy}
-   curl -sfL https://github.com/minio/directpv/raw/master/docs/tools/install.sh | sh - apply
+   curl -sfL https://github.com/minio/directpv/raw/master/docs/tools/install.sh | sh -s - apply
    ```
 
+#### Retain PodSecurityPolicy support
+
+If you upgrade to 4.1.x and wish to retain support for `PodSecurityPolicy`, complete the following steps.
+
+**Before starting the upgrade**
+
+Make a backup of the existing `psp` and `clusterrolebinding` YAML specifications.
+
+```sh {.copy}
+kubectl get psp directpv-min-io -o yaml > psp.yaml
+kubectl get clusterrolebinding psp-directpv-min-io -o yaml > psp-crb.yaml
+```
+
+**Apply the backup YAML**
+
+After completing the other upgrade steps, apply the `psp` and `clusterrolebinding` YAML backups.
+
+```sh {.copy}
+kubectl apply -f psp.yaml
+kubectl apply -f psp-crb.yaml
+```
 
 ## Upgrade legacy DirectCSI driver
 

--- a/content/installation/upgrade.md
+++ b/content/installation/upgrade.md
@@ -13,10 +13,10 @@ Use [`kubectl directpv migrate`]({{< relref "/command-line/migrate.md" >}}) to m
 
 {{< admonition title="Pod Security Policies" type="note" >}}
 Kubernetes deprecated the `PodSecurityPolicy` feature in v1.21, then removed it entirely in v1.25.
-The Kubernetes documentation [recommends](https://kubernetes.io/docs/concepts/security/pod-security-policy/) [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a replacement.
+Use [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a replacement, as recommended in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/security/pod-security-policy/).
 
-DirectPV continues to support `PodSecurityPolicy` in the 4.0.x lineage.
-The latest version of DirectPV, 4.1.x and later, removed support for `PodSecurityPolicy`.
+DirectPV continues to support `PodSecurityPolicy` in the 4.0.x versions.
+DirectPV 4.1.x and later removed support for `PodSecurityPolicy`.
 {{< /admonition >}}
 
 ## Upgrade DirectPV CSI Driver from 4.x.x to latest

--- a/content/installation/upgrade.md
+++ b/content/installation/upgrade.md
@@ -12,14 +12,11 @@ Use [`kubectl directpv migrate`]({{< relref "/command-line/migrate.md" >}}) to m
 {{< /admonition >}}
 
 {{< admonition title="Pod Security Policies" type="note" >}}
-The `PodSecurityPolicy` feature was deprecated in Kubernetes v1.21 and removed in v1.25.
-The oldest supported release of Kubernetes is v1.28.
-The [Kubernetes Documentation](https://kubernetes.io/docs/concepts/security/pod-security-policy/) recommends [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a replacement.
+Kubernetes deprecated the `PodSecurityPolicy` feature in v1.21, then removed it entirely in v1.25.
+The Kubernetes documentation [recommends]](https://kubernetes.io/docs/concepts/security/pod-security-policy/) [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a replacement.
 
 DirectPV continues to support `PodSecurityPolicy` in the 4.0.x lineage.
 The latest version of DirectPV, 4.1.x and later, removed support for `PodSecurityPolicy`.
-
-If you rely on `PodSecurityPolicy`, you **must** remain on the 4.0.x lineage of DirectPV and **must not** upgrade to a 4.1.x release or later.
 {{< /admonition >}}
 
 ## Upgrade DirectPV CSI Driver from 4.x.x to latest
@@ -45,7 +42,7 @@ Follow the steps below to perform an offline upgrade:
 
 3. [Install the latest DirectPV CSI driver]({{< relref "/installation/_index.md#driver-installation" >}}).
 
-#### In-place upgrade
+### In-place upgrade
 
 Follow the steps below to perform an in-place upgrade:
 
@@ -64,11 +61,11 @@ Follow the steps below to perform an in-place upgrade:
    curl -sfL https://github.com/minio/directpv/raw/master/docs/tools/install.sh | sh -s - apply
    ```
 
-#### Retain PodSecurityPolicy support
+### Retain PodSecurityPolicy support
 
 If you upgrade to 4.1.x and wish to retain support for `PodSecurityPolicy`, complete the following steps.
 
-**Before starting the upgrade**
+#### Before starting the upgrade
 
 Make a backup of the existing `psp` and `clusterrolebinding` YAML specifications.
 
@@ -77,7 +74,7 @@ kubectl get psp directpv-min-io -o yaml > psp.yaml
 kubectl get clusterrolebinding psp-directpv-min-io -o yaml > psp-crb.yaml
 ```
 
-**Apply the backup YAML**
+#### Apply the backup YAML
 
 After completing the other upgrade steps, apply the `psp` and `clusterrolebinding` YAML backups.
 

--- a/content/installation/upgrade.md
+++ b/content/installation/upgrade.md
@@ -13,7 +13,7 @@ Use [`kubectl directpv migrate`]({{< relref "/command-line/migrate.md" >}}) to m
 
 {{< admonition title="Pod Security Policies" type="note" >}}
 Kubernetes deprecated the `PodSecurityPolicy` feature in v1.21, then removed it entirely in v1.25.
-The Kubernetes documentation [recommends]](https://kubernetes.io/docs/concepts/security/pod-security-policy/) [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a replacement.
+The Kubernetes documentation [recommends](https://kubernetes.io/docs/concepts/security/pod-security-policy/) [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) as a replacement.
 
 DirectPV continues to support `PodSecurityPolicy` in the 4.0.x lineage.
 The latest version of DirectPV, 4.1.x and later, removed support for `PodSecurityPolicy`.


### PR DESCRIPTION
- Notes removal of PodSecurityPolicies from 4.1.x DirectPV lineage.
- Fixes a command with a missing flag (command was in two places, install and upgrade)

Closes #14

Staged:
- [DIrectPV Upgrade](http://docs-nginx.minio.training:31080/directpv-docs/docs-14/installation/upgrade/)