### PR TITLE
Updates related to DirectPV release 4.1.3

### DIFF
--- a/content/command-line/label-drives.md
+++ b/content/command-line/label-drives.md
@@ -37,11 +37,11 @@ These aliases have the same results and use the same flags as `label drives`.
 
 ### Flags
 
-| **Flag**              | **Description**                                                                                  |
-|-----------------------|--------------------------------------------------------------------------------------------------|
-| `--ids` \<string\>    | Select by drive ID                                                                               |
-| `--labels` \<string\> | Select by drive labels; supports comma separated key=value pairs, such as `tier=hot,region=east` |
-| `--status` \<string\> | Select drives by status. Valid statuses include `error`, `lost`, `moving`, `ready`, or `removed` |
+| **Flag**              | **Description**                                                                                    |
+|-----------------------|----------------------------------------------------------------------------------------------------|
+| `--ids` \<string\>    | Select by drive ID                                                                                 |
+| `--labels` \<string\> | Select by drive labels; supports comma separated `key=value` pairs, such as `tier=hot,region=east` |
+| `--status` \<string\> | Select drives by status. Valid statuses include `error`, `lost`, `moving`, `ready`, or `removed`   |
 
 ### Global Flags
 

--- a/content/command-line/label-drives.md
+++ b/content/command-line/label-drives.md
@@ -17,8 +17,12 @@ directpv label drives key=value|key- [flags]
 ```
 
 Use only one or the other of the options:
-- Use `key=value` to add a label `key` with the value of `value` to the drive(s).
-- Use `key-` to remove the label `key` from the drive(s).
+- Use `key=value` to add a custom label `key` with the value of `value` to the drive(s).
+- Use `key-` to remove the custom label `key` from the drive(s).
+  
+  Only *custom* labels can be removed.
+  Default labels used by DirectPV cannot be removed from the drive.
+
 
 ### Aliases
 
@@ -79,3 +83,6 @@ The command removes the label no matter what the value of `tier` may be on each 
 ```sh {.copy}
 kubectl directpv label drives tier- --all
 ```
+
+You can only remove custom labels.
+Default DirectPV labels cannot be removed.

--- a/content/command-line/label-volumes.md
+++ b/content/command-line/label-volumes.md
@@ -16,8 +16,11 @@ Set labels on the volumes managed by DirectPV
 directpv label volumes key=value|key- [flags]
 ```
 
-- Use `key=value` to add a label `key` with the value of `value` to the volume(s).
-- Use `key-` to remove a label `key` from the volume(s).
+- Use `key=value` to add a custom label `key` with the value of `value` to the volume(s).
+- Use `key-` to remove the custom label `key` from the volume(s).
+
+  Only *custom* labels can be removed.
+  Default labels used by DirectPV cannot be removed from the volume.
 
 ### Aliases
 
@@ -38,7 +41,7 @@ These aliases have the same results and use the same flags as `label volumes`.
 | `--pod-names` \<string\>      | Modify labels for volumes on specific pod names. You can use ellipsis pattern such as `minio-{0...4}`.       |
 | `--pod-namespaces` \<string\> | Modify labels for volumes on specific pod namespaces. You can use ellipsis pattern such as `tenant-{0...3}`. |
 | `--status` \<string\>         | Modify labels for volumes in a specific status. Valid statuses are `pending` or `ready`.                     |
-| `--labels` \<string\>         | Modify labels on volumes with the specified labels. Include multiple labels as comma separated key=value pairs, such as `tier=hot,region=east`. |
+| `--labels` \<string\>         | Modify labels on volumes with the specified labels. Include multiple labels as comma separated `key=value` pairs, such as `tier=hot,region=east`. You can only modify custom labels, not default DirectPV labels. |
 | `--ids` \<string\>            | Modify labels for a specific volume ID.                                                                      |
 
 ### Global Flags
@@ -80,3 +83,6 @@ The following command removes the label `tier` from all volumes, no matter what 
 ```sh {.copy}
 kubectl directpv label volumes tier- --all
 ```
+
+You can only remove custom labels.
+Default DirectPV labels cannot be removed.

--- a/content/command-line/list-drives.md
+++ b/content/command-line/list-drives.md
@@ -29,12 +29,12 @@ These aliases have the same results and use the same flags as `list drives`.
 
 ### Flags
 
-| **Flag**              | **Description**                                                                                        |
-|-----------------------|--------------------------------------------------------------------------------------------------------|
-| `--all`               | List all drives                                                                                        |
-| `--labels` \<string\> | Filter output by drive labels. Supports comma-separated key=value pairs such as `tier=hot,region=east` |
-| `--show-labels`       | Show all custom labels as the last column of the output (default hide labels column)                   |
-| `--status` \<string\> | Filter output by drive status. Valid statuses are `error`, `lost`, `moving`, `ready`, or `removed`     |
+| **Flag**              | **Description**                                                                                          |
+|-----------------------|----------------------------------------------------------------------------------------------------------|
+| `--all`               | List all drives                                                                                          |
+| `--labels` \<string\> | Filter output by drive labels. Supports comma-separated `key=value` pairs such as `tier=hot,region=east` |
+| `--show-labels`       | Show all custom labels as the last column of the output (default hide labels column)                     |
+| `--status` \<string\> | Filter output by drive status. Valid statuses are `error`, `lost`, `moving`, `ready`, or `removed`       |
 
 ### Global Flags
 

--- a/content/command-line/list-drives.md
+++ b/content/command-line/list-drives.md
@@ -33,7 +33,7 @@ These aliases have the same results and use the same flags as `list drives`.
 |-----------------------|--------------------------------------------------------------------------------------------------------|
 | `--all`               | List all drives                                                                                        |
 | `--labels` \<string\> | Filter output by drive labels. Supports comma-separated key=value pairs such as `tier=hot,region=east` |
-| `--show-labels`       | Show all labels as the last column of the output (default hide labels column)                          |
+| `--show-labels`       | Show all custom labels as the last column of the output (default hide labels column)                   |
 | `--status` \<string\> | Filter output by drive status. Valid statuses are `error`, `lost`, `moving`, `ready`, or `removed`     |
 
 ### Global Flags
@@ -101,7 +101,7 @@ kubectl directpv list drives --output wide
 
 ### List drives with labels
 
-The following lists drives and includes a column that shows drive labels.
+The following lists drives and includes a column that shows custom drive labels.
 
 ```sh {.copy}
 kubectl directpv list drives --show-labels

--- a/content/command-line/list-volumes.md
+++ b/content/command-line/list-volumes.md
@@ -34,7 +34,7 @@ These aliases have the same results and use the same flags as `list volumes`.
 | `--pod-namespaces` \<string\>  | Filter output by pod namespaces; supports ellipses pattern such as `tenant-{0...3}`              |
 | `--pvc`                        | Add Persistent Volume Claim (PVC) names in the output                                            |
 | `--status` \<string\>          | Filter output by volume status. Valid statuses are `pending` or `ready`.                         |
-| `--show-labels`                | Show all labels as the last column                                                               |
+| `--show-labels`                | Show all custom labels as the last column                                                        |
 | `--labels` \<string\>          | Filter output by volume labels. Enter labels as key-value pairs, such as, `tier=hot,region=east` |
 | `--all`                        | List all volumes                                                                                 |
 
@@ -122,7 +122,7 @@ kubectl directpv list volumes --drive-id=b84758b0-866f-4a12-9d00-d8f7da76ceb3
 
 ### List volumes with labels
 
-The following command lists all volumes and includes a column to show the labels assigned to each volume, if any.
+The following command lists all volumes and includes a column to show the custom labels assigned to each volume, if any.
 
 ```sh {.copy}
 kubectl directpv list volumes --show-labels


### PR DESCRIPTION
Users can now only modify custom labels, not DirectPV default labels.

The following command pages have been changed:

- list drives
- label drives
- list volumes
- label volumes

Not tracked in a DirectPV-Docs issue.

Staged:
- [list drives](http://docs-nginx.minio.training:31080/directpv-docs/4.1.3/command-line/list-drives/)
- [label drives](http://docs-nginx.minio.training:31080/directpv-docs/4.1.3/command-line/label-drives/)
- [list volumes](http://docs-nginx.minio.training:31080/directpv-docs/4.1.3/command-line/list-volumes/)
- [label volumes](http://docs-nginx.minio.training:31080/directpv-docs/4.1.3/command-line/label-volumes/)