### PR TITLE
fix: correct parameter order in replace.sh example (node, src-drive, dest-drive)

### DIFF
--- a/content/resource-management/drives.md
+++ b/content/resource-management/drives.md
@@ -148,7 +148,7 @@ Below is an example:
 
 ```sh
 # Replace 'sdd' drive by 'sdf' drive on 'node1' node
-$ replace.sh sdd sdf node1
+$ replace.sh node1 sdd sdf
 ```
 
 ### Remove drives


### PR DESCRIPTION
Hi there! While using directpv as per the guide, I noticed a typo in the `replace.sh` example and the command needs to be updated for the script to work correctly. Please let me know if there are any procedures I need to follow for this PR.
@djwfyi 

### Problem
In the `replace.sh` example, the parameters were shown in the wrong order:  
- Incorrect: `./replace.sh sdd sdf node1`

### Changes
Updated the example to match the actual script usage, with parameters in the following order:
1. Node name (`node`)
2. Source drive (`src-drive`)
3. Destination drive (`dest-drive`)

```bash
# Before
./replace.sh sdd sdf node1

# After
./replace.sh node1 sdd sdf